### PR TITLE
Uni feed without reserve (#85)

### DIFF
--- a/contracts/OverlayV1Factory.sol
+++ b/contracts/OverlayV1Factory.sol
@@ -83,11 +83,18 @@ contract OverlayV1Factory is IOverlayV1Factory {
     // events for factory functions
     event MarketDeployed(address indexed user, address market, address feed);
     event FeedFactoryAdded(address indexed user, address feedFactory);
+    event FeedFactoryRemoved(address indexed user, address feedFactory);
     event FeeRecipientUpdated(address indexed user, address recipient);
 
     // governor modifier for governance sensitive functions
     modifier onlyGovernor() {
         require(ovl.hasRole(GOVERNOR_ROLE, msg.sender), "OVLV1: !governor");
+        _;
+    }
+
+    // governor modifier for governance sensitive functions
+    modifier onlyGuardian() {
+        require(ovl.hasRole(GUARDIAN_ROLE, msg.sender), "OVLV1: !guardian");
         _;
     }
 
@@ -107,6 +114,13 @@ contract OverlayV1Factory is IOverlayV1Factory {
         require(!isFeedFactory[feedFactory], "OVLV1: feed factory already supported");
         isFeedFactory[feedFactory] = true;
         emit FeedFactoryAdded(msg.sender, feedFactory);
+    }
+
+    /// @dev removes a supported feed factory
+    function removeFeedFactory(address feedFactory) external onlyGovernor {
+        require(isFeedFactory[feedFactory], "OVLV1: address not feed factory");
+        isFeedFactory[feedFactory] = false;
+        emit FeedFactoryRemoved(msg.sender, feedFactory);
     }
 
     /// @dev deploys a new market contract
@@ -181,7 +195,7 @@ contract OverlayV1Factory is IOverlayV1Factory {
     }
 
     /// @notice Shut down of market by governance in the event of an emergency
-    function shutdown(address feed) external onlyGovernor {
+    function shutdown(address feed) external onlyGuardian {
         OverlayV1Market market = OverlayV1Market(getMarket[feed]);
         market.shutdown();
         emit EmergencyShutdown(msg.sender, address(market));

--- a/contracts/feeds/uniswapv3/OverlayV1NoReserveUniswapV3Factory.sol
+++ b/contracts/feeds/uniswapv3/OverlayV1NoReserveUniswapV3Factory.sol
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.10;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@uniswap/v3-core/contracts/interfaces/IUniswapV3Factory.sol";
+
+import "../../interfaces/feeds/uniswapv3/IOverlayV1NoReserveUniswapV3FeedFactory.sol";
+
+import "../OverlayV1FeedFactory.sol";
+import "./OverlayV1NoReserveUniswapV3Feed.sol";
+
+contract OverlayV1NoReserveUniswapV3Factory is
+    IOverlayV1NoReserveUniswapV3FeedFactory,
+    OverlayV1FeedFactory
+{
+    address public immutable uniV3Factory;
+
+    // @dev minimum observationCardinality needed for micro and macro windows
+    uint16 public immutable observationCardinalityMinimum;
+
+    // registry of feeds; for a given (pool, base, amount) pair,
+    // returns associated feed
+    mapping(address => mapping(address => mapping(uint128 => address))) public getFeed;
+
+    constructor(
+        address _uniV3Factory,
+        uint256 _microWindow,
+        uint256 _macroWindow,
+        uint16 _observationCardinalityMinimum,
+        uint256 _averageBlockTime
+    ) OverlayV1FeedFactory(_microWindow, _macroWindow) {
+        uniV3Factory = _uniV3Factory;
+
+        // sanity check on cardinality, given writes happen max once per block
+        // NOTE: need > 2 * macroWindow b/c of priceOneMacroWindowAgo
+        // SEE: Uniswap/v3-core/blob/main/contracts/libraries/Oracle.sol#L90
+        require(
+            _averageBlockTime * uint256(_observationCardinalityMinimum) >= 2 * _macroWindow,
+            "OVLV1: cardinality < 2 * macroWindow"
+        );
+        observationCardinalityMinimum = _observationCardinalityMinimum;
+    }
+
+    /// @dev deploys a new feed contract
+    /// @return feed_ address of the new feed
+    function deployFeed(
+        address marketBaseToken,
+        address marketQuoteToken,
+        uint24 marketFee,
+        uint128 marketBaseAmount
+    ) external returns (address feed_) {
+        // get the pool address for market tokens
+        address marketPool = IUniswapV3Factory(uniV3Factory).getPool(
+            marketBaseToken,
+            marketQuoteToken,
+            marketFee
+        );
+        require(marketPool != address(0), "OVLV1: !marketPool");
+
+        // check feed doesn't already exist
+        require(
+            getFeed[marketPool][marketBaseToken][marketBaseAmount] == address(0),
+            "OVLV1: feed already exists"
+        );
+
+        // Create a new Feed contract
+        feed_ = address(
+            new OverlayV1NoReserveUniswapV3Feed(
+                marketPool,
+                marketBaseToken,
+                marketQuoteToken,
+                marketBaseAmount,
+                microWindow,
+                macroWindow,
+                observationCardinalityMinimum
+            )
+        );
+
+        // store feed registry record for
+        // (marketPool, marketBaseToken, marketBaseAmount, ovlXPool) combo
+        // and record address as deployed feed
+        getFeed[marketPool][marketBaseToken][marketBaseAmount] = feed_;
+        isFeed[feed_] = true;
+        emit FeedDeployed(msg.sender, feed_);
+    }
+}

--- a/contracts/feeds/uniswapv3/OverlayV1NoReserveUniswapV3Feed.sol
+++ b/contracts/feeds/uniswapv3/OverlayV1NoReserveUniswapV3Feed.sol
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.10;
+
+import "@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol";
+
+// forks of uniswap libraries for solidity^0.8.10
+import "../../libraries/uniswap/v3-core/FullMath.sol";
+import "../../libraries/uniswap/v3-core/TickMath.sol";
+
+import "../../interfaces/feeds/uniswapv3/IOverlayV1NoReserveUniswapV3Feed.sol";
+import "../OverlayV1Feed.sol";
+
+contract OverlayV1NoReserveUniswapV3Feed is IOverlayV1NoReserveUniswapV3Feed, OverlayV1Feed {
+    // relevant pools for the feed
+    address public immutable marketPool;
+
+    // marketPool tokens
+    address public immutable marketToken0;
+    address public immutable marketToken1;
+
+    // marketPool base and quote token arrangements
+    address public immutable marketBaseToken;
+    address public immutable marketQuoteToken;
+    uint128 public immutable marketBaseAmount;
+
+    constructor(
+        address _marketPool,
+        address _marketBaseToken,
+        address _marketQuoteToken,
+        uint128 _marketBaseAmount,
+        uint256 _microWindow,
+        uint256 _macroWindow,
+        uint256 _cardinalityMarketMinimum
+    ) OverlayV1Feed(_microWindow, _macroWindow) {
+        address _marketToken0 = IUniswapV3Pool(_marketPool).token0();
+        address _marketToken1 = IUniswapV3Pool(_marketPool).token1();
+
+        require(
+            _marketToken0 == _marketBaseToken || _marketToken1 == _marketBaseToken,
+            "OVLV1: marketToken != marketBaseToken"
+        );
+        require(
+            _marketToken0 == _marketQuoteToken || _marketToken1 == _marketQuoteToken,
+            "OVLV1: marketToken != marketQuoteToken"
+        );
+
+        marketToken0 = _marketToken0;
+        marketToken1 = _marketToken1;
+
+        marketBaseToken = _marketBaseToken;
+        marketQuoteToken = _marketQuoteToken;
+        marketBaseAmount = _marketBaseAmount;
+
+        (, , , uint16 observationCardinalityMarket, , , ) = IUniswapV3Pool(_marketPool).slot0();
+        require(
+            observationCardinalityMarket >= _cardinalityMarketMinimum,
+            "OVLV1: marketCardinality < min"
+        );
+
+        marketPool = _marketPool;
+    }
+
+    /// @dev fetches TWAP, liquidity data from the univ3 pool oracle
+    /// @dev for micro and macro window averaging intervals.
+    function _fetch() internal view virtual override returns (Oracle.Data memory) {
+        // consult to market pool
+        // secondsAgo.length = 4; twaps.length = liqs.length = 3
+        (
+            uint32[] memory secondsAgos,
+            uint32[] memory windows,
+            uint256[] memory nowIdxs
+        ) = _inputsToConsultMarketPool(microWindow, macroWindow);
+
+        int24[] memory arithmeticMeanTicksMarket = consult(
+            marketPool,
+            secondsAgos,
+            windows,
+            nowIdxs
+        );
+
+        // in terms of prices, will use for indexes
+        //  0: priceOneMacroWindowAgo: prices[0]
+        //  1: priceOverMacroWindow: prices[1]
+        //  2: priceOverMicroWindow: prices[2]
+        // window: [now - macroWindow * 2, now - macroWindow]
+        uint256 priceOneMacroWindowAgo = getQuoteAtTick(
+            arithmeticMeanTicksMarket[0],
+            marketBaseAmount,
+            marketBaseToken,
+            marketQuoteToken
+        );
+        // window: [now - macroWindow, now]
+        uint256 priceOverMacroWindow = getQuoteAtTick(
+            arithmeticMeanTicksMarket[1],
+            marketBaseAmount,
+            marketBaseToken,
+            marketQuoteToken
+        );
+        // window: [now - microWindow, now]
+        uint256 priceOverMicroWindow = getQuoteAtTick(
+            arithmeticMeanTicksMarket[2],
+            marketBaseAmount,
+            marketBaseToken,
+            marketQuoteToken
+        );
+
+        return
+            Oracle.Data({
+                timestamp: block.timestamp,
+                microWindow: microWindow,
+                macroWindow: macroWindow,
+                priceOverMicroWindow: priceOverMicroWindow,
+                priceOverMacroWindow: priceOverMacroWindow,
+                priceOneMacroWindowAgo: priceOneMacroWindowAgo,
+                reserveOverMicroWindow: 0,
+                hasReserve: false
+            });
+    }
+
+    /// @dev returns input params needed for call to marketPool consult
+    function _inputsToConsultMarketPool(uint256 _microWindow, uint256 _macroWindow)
+        private
+        pure
+        returns (
+            uint32[] memory,
+            uint32[] memory,
+            uint256[] memory
+        )
+    {
+        uint32[] memory secondsAgos = new uint32[](4);
+        uint32[] memory windows = new uint32[](3);
+        uint256[] memory nowIdxs = new uint256[](3);
+
+        // number of seconds in past for which we want accumulator snapshot
+        // for Oracle.Data, need:
+        //  0: now - 2 * macroWindow (2 * macroWindow seconds ago)
+        //  1: now - macroWindow (macroWindow seconds ago)
+        //  2: now - microWindow (microWindow seconds ago)
+        //  3: now (0 seconds ago)
+        secondsAgos[0] = uint32(_macroWindow * 2);
+        secondsAgos[1] = uint32(_macroWindow);
+        secondsAgos[2] = uint32(_microWindow);
+        secondsAgos[3] = 0;
+
+        // window lengths for each cumulative differencing
+        // in terms of prices, will use for indexes
+        //  0: priceOneMacroWindowAgo
+        //  1: priceOverMacroWindow
+        //  2: priceOverMicroWindow
+        windows[0] = uint32(_macroWindow);
+        windows[1] = uint32(_macroWindow);
+        windows[2] = uint32(_microWindow);
+
+        // index of secondsAgos which we treat as current time when differencing
+        // for mean calcs
+        //  0: priceOneMacroWindowAgo
+        //  1: priceOverMacroWindow
+        //  2: priceOverMicroWindow
+        nowIdxs[0] = 1;
+        nowIdxs[1] = 3;
+        nowIdxs[2] = 3;
+
+        return (secondsAgos, windows, nowIdxs);
+    }
+
+    /// @dev COPIED AND MODIFIED FROM: Uniswap/v3-periphery/contracts/libraries/OracleLibrary.sol
+    /// @dev assumes nows elements are the current cumulative value from which we
+    /// @dev want to calculate rolling average tick and liquidity values
+    function consult(
+        address pool,
+        uint32[] memory secondsAgos,
+        uint32[] memory windows,
+        uint256[] memory nowIdxs
+    ) public view returns (int24[] memory arithmeticMeanTicks_) {
+        (
+            int56[] memory tickCumulatives,
+            uint160[] memory secondsPerLiquidityCumulativeX128s
+        ) = IUniswapV3Pool(pool).observe(secondsAgos);
+
+        uint256 nowIdxsLength = nowIdxs.length;
+        arithmeticMeanTicks_ = new int24[](nowIdxsLength);
+
+        for (uint256 i = 0; i < nowIdxsLength; i++) {
+            uint256 nowIdx = nowIdxs[i];
+            uint32 window = windows[i];
+
+            int56 tickCumulativesDelta = tickCumulatives[nowIdx] - tickCumulatives[i];
+
+            int24 arithmeticMeanTick = int24(tickCumulativesDelta / int56(uint56(window)));
+            // Always round to negative infinity
+            if (tickCumulativesDelta < 0 && (tickCumulativesDelta % int56(uint56(window)) != 0))
+                arithmeticMeanTick--;
+
+            arithmeticMeanTicks_[i] = arithmeticMeanTick;
+        }
+    }
+
+    /// @dev COPIED AND MODIFIED FROM: Uniswap/v3-periphery/contracts/libraries/OracleLibrary.sol
+    function getQuoteAtTick(
+        int24 tick,
+        uint128 baseAmount,
+        address baseToken,
+        address quoteToken
+    ) public view returns (uint256 quoteAmount_) {
+        uint160 sqrtRatioX96 = TickMath.getSqrtRatioAtTick(tick);
+
+        // Calculate quoteAmount with better precision if it doesn't overflow when multiplied by
+        // itself
+        if (sqrtRatioX96 <= type(uint128).max) {
+            uint256 ratioX192 = uint256(sqrtRatioX96) * sqrtRatioX96;
+            quoteAmount_ = baseToken < quoteToken
+                ? FullMath.mulDiv(ratioX192, baseAmount, 1 << 192)
+                : FullMath.mulDiv(1 << 192, baseAmount, ratioX192);
+        } else {
+            uint256 ratioX128 = FullMath.mulDiv(sqrtRatioX96, sqrtRatioX96, 1 << 64);
+            quoteAmount_ = baseToken < quoteToken
+                ? FullMath.mulDiv(ratioX128, baseAmount, 1 << 128)
+                : FullMath.mulDiv(1 << 128, baseAmount, ratioX128);
+        }
+    }
+}

--- a/contracts/interfaces/IOverlayV1Factory.sol
+++ b/contracts/interfaces/IOverlayV1Factory.sol
@@ -32,6 +32,9 @@ interface IOverlayV1Factory {
     // adding feed factory to allowed feed types
     function addFeedFactory(address feedFactory) external;
 
+    // removing feed factory from allowed feed types
+    function removeFeedFactory(address feedFactory) external;
+
     // deploy new market
     function deployMarket(
         address feedFactory,

--- a/contracts/interfaces/IOverlayV1Token.sol
+++ b/contracts/interfaces/IOverlayV1Token.sol
@@ -7,6 +7,7 @@ import "@openzeppelin/contracts/access/IAccessControlEnumerable.sol";
 bytes32 constant MINTER_ROLE = keccak256("MINTER");
 bytes32 constant BURNER_ROLE = keccak256("BURNER");
 bytes32 constant GOVERNOR_ROLE = keccak256("GOVERNOR");
+bytes32 constant GUARDIAN_ROLE = keccak256("GUARDIAN");
 
 interface IOverlayV1Token is IAccessControlEnumerable, IERC20 {
     // mint/burn

--- a/contracts/interfaces/feeds/uniswapv3/IOverlayV1NoReserveUniswapV3Feed.sol
+++ b/contracts/interfaces/feeds/uniswapv3/IOverlayV1NoReserveUniswapV3Feed.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.10;
+
+import "../IOverlayV1Feed.sol";
+
+interface IOverlayV1NoReserveUniswapV3Feed is IOverlayV1Feed {
+    function marketPool() external view returns (address);
+
+    function marketToken0() external view returns (address);
+
+    function marketToken1() external view returns (address);
+
+    function marketBaseToken() external view returns (address);
+
+    function marketQuoteToken() external view returns (address);
+
+    function marketBaseAmount() external view returns (uint128);
+
+    // COPIED AND MODIFIED FROM: Uniswap/v3-periphery/contracts/libraries/OracleLibrary.sol
+    function consult(
+        address pool,
+        uint32[] memory secondsAgos,
+        uint32[] memory windows,
+        uint256[] memory nowIdxs
+    ) external view returns (int24[] memory arithmeticMeanTicks_);
+
+    // COPIED AND MODIFIED FROM: Uniswap/v3-periphery/contracts/libraries/OracleLibrary.sol
+    function getQuoteAtTick(
+        int24 tick,
+        uint128 baseAmount,
+        address baseToken,
+        address quoteToken
+    ) external view returns (uint256 quoteAmount_);
+}

--- a/contracts/interfaces/feeds/uniswapv3/IOverlayV1NoReserveUniswapV3FeedFactory.sol
+++ b/contracts/interfaces/feeds/uniswapv3/IOverlayV1NoReserveUniswapV3FeedFactory.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.10;
+
+import "../IOverlayV1FeedFactory.sol";
+
+interface IOverlayV1NoReserveUniswapV3FeedFactory is IOverlayV1FeedFactory {
+    function uniV3Factory() external view returns (address);
+
+    // @dev minimum observationCardinality needed for micro and macro windows
+    function observationCardinalityMinimum() external view returns (uint16);
+
+    // registry of feeds; for a given (pool, base, quote, amount) pair, returns associated feed
+    function getFeed(
+        address marketPool,
+        address marketBaseToken,
+        uint128 marketBaseAmount
+    ) external view returns (address feed_);
+
+    /// @dev deploys a new feed contract
+    /// @return feed_ address of the new feed
+    function deployFeed(
+        address marketBaseToken,
+        address marketQuoteToken,
+        uint24 marketFee,
+        uint128 marketBaseAmount
+    ) external returns (address feed_);
+}

--- a/tests/factories/feed/univ3/conftest.py
+++ b/tests/factories/feed/univ3/conftest.py
@@ -1,5 +1,7 @@
 import pytest
-from brownie import Contract, OverlayV1UniswapV3Factory
+from brownie import (
+    Contract, OverlayV1UniswapV3Factory, OverlayV1NoReserveUniswapV3Factory
+)
 
 
 @pytest.fixture(scope="module")
@@ -47,6 +49,30 @@ def pool_daiweth_30bps():
 def pool_uniweth_30bps():
     # to be used as example ovlweth pool
     yield Contract.from_explorer("0x1d42064Fc4Beb5F8aAF85F4617AE8b3b5B8Bd801")
+
+
+@pytest.fixture(scope="module", params=[(600, 1800, 240, 15)])
+def create_factory_without_reserve(gov, uni_factory, weth, request):
+    micro, macro, cardinality, block_time = request.param
+    uni_fact = uni_factory.address
+
+    def create_factory_without_reserve(
+            univ3_factory=uni_fact,
+            micro_window=micro, macro_window=macro,
+            cardinality_min=cardinality,
+            avg_block_time=block_time):
+        factory = gov.deploy(
+                        OverlayV1NoReserveUniswapV3Factory, univ3_factory,
+                        micro_window, macro_window, cardinality_min,
+                        avg_block_time)
+        return factory
+
+    yield create_factory_without_reserve
+
+
+@pytest.fixture(scope="module")
+def factory_without_reserve(create_factory_without_reserve):
+    yield create_factory_without_reserve()
 
 
 # TODO: change params to (600, 3600, 300, 14)

--- a/tests/factories/feed/univ3/test_deploy_factory.py
+++ b/tests/factories/feed/univ3/test_deploy_factory.py
@@ -1,4 +1,6 @@
-from brownie import OverlayV1UniswapV3Factory, reverts
+from brownie import (
+    OverlayV1NoReserveUniswapV3Factory, OverlayV1UniswapV3Factory, reverts
+)
 
 
 def test_deploy_factory_reverts_when_cardinality_lt_macro(alice, uni,
@@ -13,5 +15,21 @@ def test_deploy_factory_reverts_when_cardinality_lt_macro(alice, uni,
     cardinality_min = 10
     with reverts("OVLV1: cardinality < 2 * macroWindow"):
         _ = alice.deploy(OverlayV1UniswapV3Factory, ovl, uni_factory,
+                         micro_window, macro_window, cardinality_min,
+                         avg_block_time)
+
+
+def test_deploy_no_reserve_factory_reverts_when_cardinality_lt_macro(
+        alice,
+        uni_factory):
+    micro_window = 600
+    macro_window = 3600
+    avg_block_time = 14
+
+    # check factory deploy reverts when cardinality too small given
+    # micro and macro windows
+    cardinality_min = 10
+    with reverts("OVLV1: cardinality < 2 * macroWindow"):
+        _ = alice.deploy(OverlayV1NoReserveUniswapV3Factory, uni_factory,
                          micro_window, macro_window, cardinality_min,
                          avg_block_time)

--- a/tests/factories/feed/univ3/test_deploy_feed.py
+++ b/tests/factories/feed/univ3/test_deploy_feed.py
@@ -1,5 +1,42 @@
-from brownie import reverts, OverlayV1UniswapV3Feed
+from brownie import (
+    reverts, OverlayV1UniswapV3Feed, OverlayV1NoReserveUniswapV3Feed
+)
 from collections import OrderedDict
+
+
+def test_deploy_feed_creates_quanto_feed_without_reserve(
+        factory_without_reserve, pool_daiweth_30bps, dai, weth, alice):
+
+    market_pool = pool_daiweth_30bps
+    market_fee = 3000
+
+    market_base_token = weth
+    market_quote_token = dai
+    market_base_amount = 1e18
+
+    tx = factory_without_reserve.deployFeed(market_base_token,
+                                            market_quote_token,
+                                            market_fee,
+                                            market_base_amount,
+                                            {'from': alice})
+
+    actual_feed = tx.return_value
+
+    assert factory_without_reserve.getFeed(
+        market_pool, market_base_token, market_base_amount) == actual_feed
+    assert factory_without_reserve.isFeed(actual_feed) is True
+
+    assert 'FeedDeployed' in tx.events
+    expect_event = OrderedDict({"user": alice.address, "feed": actual_feed})
+    actual_event = tx.events['FeedDeployed']
+    assert actual_event == expect_event
+
+    feed_contract = OverlayV1NoReserveUniswapV3Feed.at(actual_feed)
+    assert feed_contract.feedFactory() == factory_without_reserve
+    assert feed_contract.marketPool() == market_pool
+    assert feed_contract.marketBaseToken() == market_base_token
+    assert feed_contract.marketQuoteToken() == market_quote_token
+    assert feed_contract.marketBaseAmount() == market_base_amount
 
 
 def test_deploy_feed_creates_quanto_feed(factory, pool_uniweth_30bps, uni,
@@ -85,6 +122,39 @@ def test_deploy_feed_creates_inverse_feed(factory, pool_uniweth_30bps, uni,
     assert feed_contract.marketBaseAmount() == market_base_amount
 
 
+def test_deploy_no_reserve_feed_reverts_when_market_pool_not_exists(
+        factory_without_reserve, alice, bob, pool_daiweth_30bps, dai, weth):
+
+    market_base_amount = 1000000000000000000  # 1e18
+
+    # check reverts when base token not in pool
+    market_fee = 3000
+    market_base_token = bob
+    market_quote_token = dai
+    with reverts("OVLV1: !marketPool"):
+        _ = factory_without_reserve.deployFeed(
+                market_base_token, market_quote_token,
+                market_fee, market_base_amount, {"from": alice})
+
+    # check reverts when quote token not in pool
+    market_fee = 3000
+    market_base_token = weth
+    market_quote_token = bob
+    with reverts("OVLV1: !marketPool"):
+        _ = factory_without_reserve.deployFeed(
+                market_base_token, market_quote_token,
+                market_fee, market_base_amount, {"from": alice})
+
+    # check reverts when fee not in pool
+    market_fee = 215
+    market_base_token = weth
+    market_quote_token = dai
+    with reverts("OVLV1: !marketPool"):
+        _ = factory_without_reserve.deployFeed(
+                market_base_token, market_quote_token,
+                market_fee, market_base_amount, {"from": alice})
+
+
 def test_deploy_feed_reverts_when_market_pool_not_exists(factory, alice, bob,
                                                          pool_daiweth_30bps,
                                                          pool_uniweth_30bps,
@@ -164,6 +234,31 @@ def test_deploy_feed_reverts_when_ovlx_pool_not_exists(factory, alice, bob,
                                market_fee, market_base_amount,
                                ovlweth_base_token, ovlweth_quote_token,
                                ovlweth_fee, {"from": alice})
+
+
+def test_deploy_no_reserve_feed_reverts_when_feed_already_exists(
+        factory_without_reserve, dai,
+        weth, pool_daiweth_30bps, alice):
+
+    market_pool = pool_daiweth_30bps
+    market_fee = 3000
+    market_base_token = weth
+    market_quote_token = dai
+    market_base_amount = 1000000000000000000  # 1e18
+
+    # Check feed already exists first from prior unit test above
+    feed = factory_without_reserve.getFeed(market_pool,
+                                           market_base_token,
+                                           market_base_amount)
+    assert factory_without_reserve.isFeed(feed) is True
+
+    # check reverts when attempt to deploy again
+    with reverts("OVLV1: feed already exists"):
+        _ = factory_without_reserve.deployFeed(
+                                        market_base_token,
+                                        market_quote_token,
+                                        market_fee,
+                                        market_base_amount, {"from": alice})
 
 
 def test_deploy_feed_reverts_when_feed_already_exists(factory, uni, dai, weth,

--- a/tests/factories/market/conftest.py
+++ b/tests/factories/market/conftest.py
@@ -37,6 +37,11 @@ def fee_recipient(accounts):
 
 
 @pytest.fixture(scope="module")
+def guardian(accounts):
+    yield accounts[6]
+
+
+@pytest.fixture(scope="module")
 def minter_role():
     yield web3.solidityKeccak(['string'], ["MINTER"])
 
@@ -49,6 +54,11 @@ def burner_role():
 @pytest.fixture(scope="module")
 def governor_role():
     yield web3.solidityKeccak(['string'], ["GOVERNOR"])
+
+
+@pytest.fixture(scope="module")
+def guardian_role():
+    yield web3.solidityKeccak(['string'], ["GUARDIAN"])
 
 
 @pytest.fixture(scope="module", params=[8000000])
@@ -132,8 +142,8 @@ def feed_three(feed_factory):
 
 
 @pytest.fixture(scope="module")
-def create_factory(gov, fee_recipient, request, ovl, governor_role,
-                   feed_factory, feed_three):
+def create_factory(gov, guardian, fee_recipient, request, ovl, governor_role,
+                   guardian_role, feed_factory, feed_three):
 
     def create_factory(tok=ovl, recipient=fee_recipient, feeds=feed_factory,
                        feed=feed_three):
@@ -145,6 +155,8 @@ def create_factory(gov, fee_recipient, request, ovl, governor_role,
 
         # grant gov the governor role on token to access factory methods
         tok.grantRole(governor_role, gov, {"from": gov})
+        # grant gov the guardian role on token to access factory methods
+        tok.grantRole(guardian_role, guardian, {"from": gov})
 
         # add the feed factory
         factory.addFeedFactory(feeds, {"from": gov})

--- a/tests/factories/market/test_add_remove_feed_factory.py
+++ b/tests/factories/market/test_add_remove_feed_factory.py
@@ -29,3 +29,30 @@ def test_add_feed_factory_reverts_when_factory_already_exists(factory,
     # check reverts when already supporting factory
     with reverts("OVLV1: feed factory already supported"):
         _ = factory.addFeedFactory(feed_factory, {"from": gov})
+
+
+def test_remove_feed_factory_removes_feed_factory(factory, rando, gov):
+    assert factory.isFeedFactory(rando) is True
+
+    tx = factory.removeFeedFactory(rando, {"from": gov})
+
+    assert 'FeedFactoryRemoved' in tx.events
+    expect_event = OrderedDict({"user": gov.address, "feedFactory": rando})
+    actual_event = tx.events['FeedFactoryRemoved']
+    assert actual_event == expect_event
+
+
+def test_remove_feed_factory_reverts_when_not_gov(factory, rando, gov):
+    _ = factory.addFeedFactory(rando, {"from": gov})
+
+    assert factory.isFeedFactory(rando) is True
+
+    with reverts("OVLV1: !governor"):
+        _ = factory.removeFeedFactory(rando, {"from": rando})
+
+
+def test_remove_feed_factory_reverts_when_not_feed_factory(factory,
+                                                           alice,
+                                                           gov):
+    with reverts("OVLV1: address not feed factory"):
+        _ = factory.removeFeedFactory(alice, {"from": gov})

--- a/tests/factories/market/test_setters.py
+++ b/tests/factories/market/test_setters.py
@@ -144,14 +144,14 @@ def test_set_risk_param_reverts_when_greater_than_max(factory, market, gov):
 
 
 # shutdown tests
-def test_shutdown(factory, market, gov):
+def test_shutdown(factory, market, guardian):
     feed = market.feed()
 
     # check hasn't been shut down yet
     assert market.isShutdown() is False
 
     # shut the market down
-    tx = factory.shutdown(feed, {"from": gov})
+    tx = factory.shutdown(feed, {"from": guardian})
 
     # check now set to shutdown
     market.isShutdown() is True
@@ -159,16 +159,16 @@ def test_shutdown(factory, market, gov):
     # check event emitted
     assert 'EmergencyShutdown' in tx.events
     expect_event = OrderedDict({
-        "user": gov,
+        "user": guardian,
         "market": market
     })
     actual_event = tx.events['EmergencyShutdown']
     assert actual_event == expect_event
 
 
-def test_shutdown_reverts_when_not_gov(factory, market, rando):
+def test_shutdown_reverts_when_not_guardian(factory, market, rando):
     feed = market.feed()
 
-    # can't shutdown when not a governor
-    with reverts("OVLV1: !governor"):
+    # can't shutdown when not a guardian
+    with reverts("OVLV1: !guardian"):
         _ = factory.shutdown(feed, {"from": rando})

--- a/tests/feeds/uniswapv3/test_integration.py
+++ b/tests/feeds/uniswapv3/test_integration.py
@@ -11,6 +11,8 @@ def test_consult_for_daiweth(pool_daiweth_30bps, quanto_feed):
                                                             seconds_agos,
                                                             windows,
                                                             now_idxs)
+    print("tick_cums", tick_cums)
+    print("actual_avg_ticks", actual_avg_ticks)
 
     # calculate expect arithmetic means for ticks and harmonic
     # mean for liquidity to compare w actuals
@@ -23,6 +25,25 @@ def test_consult_for_daiweth(pool_daiweth_30bps, quanto_feed):
         # rel=1e-4 is needed for rounding with ticks
         assert approx(expect_avg_tick, rel=1e-4) == actual_avg_ticks[i]
         assert approx(expect_avg_liq) == actual_avg_liqs[i]
+
+
+def test_consult_for_daiweth_without_reserve(pool_daiweth_30bps,
+                                             quanto_feed_without_reserve):
+    seconds_agos = [7200, 3600, 600, 0]
+    windows = [3600, 3600, 600]
+    now_idxs = [1, len(seconds_agos)-1, len(seconds_agos)-1]
+
+    tick_cums, _ = pool_daiweth_30bps.observe(seconds_agos)
+    actual_avg_ticks = quanto_feed_without_reserve.consult(pool_daiweth_30bps,
+                                                           seconds_agos,
+                                                           windows,
+                                                           now_idxs)
+    print("tick cums", tick_cums)
+    print("actual avg ticks", actual_avg_ticks)
+
+    for i in range(len(windows)):
+        expect_avg_tick = int((tick_cums[now_idxs[i]]-tick_cums[i])/windows[i])
+        assert approx(expect_avg_tick, rel=1e-4) == actual_avg_ticks[i]
 
 
 def test_consult_for_uniweth(pool_uniweth_30bps, inverse_feed):

--- a/tests/feeds/uniswapv3/test_latest.py
+++ b/tests/feeds/uniswapv3/test_latest.py
@@ -1,6 +1,38 @@
 from brownie import chain
 
 
+def test_latest_updates_data_on_first_call_for_quanto_feed_without_reserve(
+        pool_daiweth_30bps,
+        quanto_feed_without_reserve):
+    micro_window = quanto_feed_without_reserve.microWindow()
+    macro_window = quanto_feed_without_reserve.macroWindow()
+    market_base_amount = quanto_feed_without_reserve.marketBaseAmount()
+    market_base_token = quanto_feed_without_reserve.marketBaseToken()
+    market_quote_token = quanto_feed_without_reserve.marketQuoteToken()
+    timestamp = chain[-1]['timestamp']
+
+    actual = quanto_feed_without_reserve.latest()
+
+    seconds_agos = [2 * macro_window, macro_window, micro_window, 0]
+    windows = [macro_window, macro_window, micro_window]
+    now_idxs = [1, len(seconds_agos)-1, len(seconds_agos)-1]
+
+    market_avg_ticks = quanto_feed_without_reserve.consult(
+        pool_daiweth_30bps, seconds_agos, windows, now_idxs)
+
+    prices = []
+    has_reserve = False
+    for i in range(len(now_idxs)):
+        prices.append(quanto_feed_without_reserve.getQuoteAtTick(
+            market_avg_ticks[i], market_base_amount,
+            market_base_token, market_quote_token))
+
+    expect = (timestamp, micro_window, macro_window, prices[2], prices[1],
+              prices[0], 0, has_reserve)
+
+    assert expect == actual
+
+
 def test_latest_updates_data_on_first_call_for_quanto_feed(pool_daiweth_30bps,
                                                            pool_uniweth_30bps,
                                                            quanto_feed):
@@ -128,6 +160,42 @@ def test_latest_updates_data_on_many_calls_for_quanto_feed(pool_daiweth_30bps,
 
         expect = (timestamp, micro_window, macro_window, prices[2], prices[1],
                   prices[0], reserves[2], has_reserve)
+
+        assert expect == actual
+
+
+def test_latest_updates_data_on_many_calls_for_quanto_feed_without_reserve(
+        pool_daiweth_30bps,
+        quanto_feed_without_reserve):
+    micro_window = quanto_feed_without_reserve.microWindow()
+    macro_window = quanto_feed_without_reserve.macroWindow()
+    market_base_amount = quanto_feed_without_reserve.marketBaseAmount()
+    market_base_token = quanto_feed_without_reserve.marketBaseToken()
+    market_quote_token = quanto_feed_without_reserve.marketQuoteToken()
+
+    for i in range(3):
+
+        chain.mine(timedelta=60)
+        timestamp = chain[-1]['timestamp']
+
+        actual = quanto_feed_without_reserve.latest()
+
+        seconds_agos = [2 * macro_window, macro_window, micro_window, 0]
+        windows = [macro_window, macro_window, micro_window]
+        now_idxs = [1, len(seconds_agos)-1, len(seconds_agos)-1]
+
+        market_avg_ticks = quanto_feed_without_reserve.consult(
+            pool_daiweth_30bps, seconds_agos, windows, now_idxs)
+
+        prices = []
+        has_reserve = False
+        for i in range(len(now_idxs)):
+            prices.append(quanto_feed_without_reserve.getQuoteAtTick(
+                market_avg_ticks[i], market_base_amount,
+                market_base_token, market_quote_token))
+
+        expect = (timestamp, micro_window, macro_window, prices[2], prices[1],
+                  prices[0], 0, has_reserve)
 
         assert expect == actual
 

--- a/tests/feeds/uniswapv3/test_views.py
+++ b/tests/feeds/uniswapv3/test_views.py
@@ -1,6 +1,24 @@
 from pytest import approx
 
 
+def test_get_quote_at_tick_for_daiweth_without_reserve(
+        dai, weth, quanto_feed_without_reserve):
+    # from Uniswap whitepaper: price = 1.0001^tick
+    tick = -82944  # num_dai / num_weth ~ 4000
+    base_amount = 1e18
+    base_token = weth
+    quote_token = dai
+
+    # flip expect tick based off uniswap convention of base/quote if need to
+    expect_sign = -1 if base_token.address > quote_token.address else 1
+    expect_quote_amount = int(base_amount * 1.0001 ** (expect_sign * tick))
+
+    actual_quote_amount = quanto_feed_without_reserve.getQuoteAtTick(
+        tick, base_amount, base_token, quote_token
+    )
+    assert approx(expect_quote_amount) == actual_quote_amount
+
+
 def test_get_quote_at_tick_for_daiweth(dai, weth, quanto_feed):
     # from Uniswap whitepaper: price = 1.0001^tick
     tick = -82944  # num_dai / num_weth ~ 4000

--- a/tests/markets/conftest.py
+++ b/tests/markets/conftest.py
@@ -37,6 +37,11 @@ def fake_factory(accounts):
 
 
 @pytest.fixture(scope="module")
+def guardian(accounts):
+    yield accounts[6]
+
+
+@pytest.fixture(scope="module")
 def minter_role():
     yield web3.solidityKeccak(['string'], ["MINTER"])
 
@@ -49,6 +54,11 @@ def burner_role():
 @pytest.fixture(scope="module")
 def governor_role():
     yield web3.solidityKeccak(['string'], ["GOVERNOR"])
+
+
+@pytest.fixture(scope="module")
+def guardian_role():
+    yield web3.solidityKeccak(['string'], ["GUARDIAN"])
 
 
 @pytest.fixture(scope="module", params=[8000000])
@@ -227,8 +237,8 @@ def mock_feed(create_mock_feed):
 
 
 @pytest.fixture(scope="module")
-def create_factory(gov, fee_recipient, request, ovl, governor_role,
-                   feed_factory, mock_feed_factory):
+def create_factory(gov, guardian, fee_recipient, request, ovl, governor_role,
+                   guardian_role, feed_factory, mock_feed_factory):
     def create_factory(tok=ovl, recipient=fee_recipient):
         # create the market factory
         factory = gov.deploy(OverlayV1Factory, tok, recipient)
@@ -238,6 +248,8 @@ def create_factory(gov, fee_recipient, request, ovl, governor_role,
 
         # grant gov the governor role on token to access factory methods
         tok.grantRole(governor_role, gov, {"from": gov})
+        # grant gov the guardian role on token to access factory methods
+        tok.grantRole(guardian_role, guardian, {"from": gov})
 
         # add both feed factories
         factory.addFeedFactory(feed_factory, {"from": gov})

--- a/tests/markets/test_build.py
+++ b/tests/markets/test_build.py
@@ -852,7 +852,7 @@ def test_build_reverts_when_oi_zero(mock_market, mock_feed, ovl, alice, bob):
 
 
 def test_build_reverts_when_has_shutdown(factory, feed, market, ovl,
-                                         alice, gov):
+                                         alice, guardian):
     # build inputs
     input_collateral = int(1e18)
     input_leverage = int(1e18)
@@ -871,7 +871,7 @@ def test_build_reverts_when_has_shutdown(factory, feed, market, ovl,
 
     # shutdown market
     # NOTE: factory.shutdown() tests in factories/market/test_setters.py
-    factory.shutdown(feed, {"from": gov})
+    factory.shutdown(feed, {"from": guardian})
 
     # attempt to build again
     with reverts("OVLV1: shutdown"):

--- a/tests/markets/test_liquidate.py
+++ b/tests/markets/test_liquidate.py
@@ -1728,7 +1728,7 @@ def test_liquidate_reverts_when_position_not_liquidatable(mock_market,
 
 
 def test_liquidate_reverts_when_has_shutdown(factory, mock_feed, mock_market,
-                                             ovl, alice, gov, rando):
+                                             ovl, alice, guardian, rando):
     # build inputs
     input_collateral = int(1e18)
     input_leverage = int(2e18)
@@ -1760,7 +1760,7 @@ def test_liquidate_reverts_when_has_shutdown(factory, mock_feed, mock_market,
 
     # shutdown market
     # NOTE: factory.shutdown() tests in factories/market/test_setters.py
-    factory.shutdown(mock_feed, {"from": gov})
+    factory.shutdown(mock_feed, {"from": guardian})
 
     # attempt to liquidate
     with reverts("OVLV1: shutdown"):

--- a/tests/markets/test_unwind.py
+++ b/tests/markets/test_unwind.py
@@ -2009,7 +2009,7 @@ def test_unwind_reverts_when_position_liquidatable(mock_market, mock_feed,
 
 
 def test_unwind_reverts_when_has_shutdown(factory, feed, market, ovl,
-                                          alice, gov):
+                                          alice, guardian):
     # build inputs
     input_collateral = int(1e18)
     input_leverage = int(1e18)
@@ -2035,7 +2035,7 @@ def test_unwind_reverts_when_has_shutdown(factory, feed, market, ovl,
 
     # shutdown market
     # NOTE: factory.shutdown() tests in factories/market/test_setters.py
-    factory.shutdown(feed, {"from": gov})
+    factory.shutdown(feed, {"from": guardian})
 
     # attempt to unwind again
     with reverts("OVLV1: shutdown"):

--- a/tests/markets/test_withdraw.py
+++ b/tests/markets/test_withdraw.py
@@ -45,7 +45,7 @@ def test_shutdown_reverts_when_not_factory(market, rando):
 
 # emergency withdraw tests
 def test_emergency_withdraw_transfers_collateral(
-        mock_market, mock_feed, factory, ovl, alice, gov, rando):
+        mock_market, mock_feed, factory, ovl, alice, guardian, rando):
     # input build parameters
     input_collateral = int(1e18)
     input_leverage = int(1e18)
@@ -75,7 +75,7 @@ def test_emergency_withdraw_transfers_collateral(
 
     # shutdown market
     # NOTE: factory.shutdown() tests in factories/market/test_setters.py
-    factory.shutdown(mock_feed, {"from": gov})
+    factory.shutdown(mock_feed, {"from": guardian})
 
     expect_collateral_out = int(
         Decimal(input_collateral) * (Decimal(1e18) - Decimal(fraction))
@@ -109,7 +109,7 @@ def test_emergency_withdraw_transfers_collateral(
 
 
 def test_emergency_withdraw_updates_position(
-        mock_market, mock_feed, factory, ovl, alice, gov, rando):
+        mock_market, mock_feed, factory, ovl, alice, guardian, rando):
     # input build parameters
     input_collateral = int(1e18)
     input_leverage = int(1e18)
@@ -139,7 +139,7 @@ def test_emergency_withdraw_updates_position(
 
     # shutdown market
     # NOTE: factory.shutdown() tests in factories/market/test_setters.py
-    factory.shutdown(mock_feed, {"from": gov})
+    factory.shutdown(mock_feed, {"from": guardian})
 
     # emergency withdraw collateral
     _ = mock_market.emergencyWithdraw(input_pos_id, {"from": alice})
@@ -157,7 +157,7 @@ def test_emergency_withdraw_updates_position(
 
 
 def test_emergency_withdraw_executes_transfers(
-        mock_market, mock_feed, factory, ovl, alice, gov, rando):
+        mock_market, mock_feed, factory, ovl, alice, guardian, rando):
     # input build parameters
     input_collateral = int(1e18)
     input_leverage = int(1e18)
@@ -187,7 +187,7 @@ def test_emergency_withdraw_executes_transfers(
 
     # shutdown market
     # NOTE: factory.shutdown() tests in factories/market/test_setters.py
-    factory.shutdown(mock_feed, {"from": gov})
+    factory.shutdown(mock_feed, {"from": guardian})
 
     # calculate the expected collateral amount transferred
     expect_collateral_out = int(
@@ -226,12 +226,12 @@ def test_emergency_withdraw_reverts_when_not_shutdown(market, ovl, alice):
 
 def test_emergency_withdraw_reverts_when_position_not_exists(market, feed, ovl,
                                                              factory, alice,
-                                                             gov):
+                                                             guardian):
     input_pos_id = 100
 
     # shutdown market
     # NOTE: factory.shutdown() tests in factories/market/test_setters.py
-    factory.shutdown(feed, {"from": gov})
+    factory.shutdown(feed, {"from": guardian})
 
     # check can't withdraw collateral when no position exists
     with reverts("OVLV1:!position"):
@@ -239,7 +239,7 @@ def test_emergency_withdraw_reverts_when_position_not_exists(market, feed, ovl,
 
 
 def test_multiple_emergency_withdraw(
-        mock_market, mock_feed, factory, ovl, alice, bob, gov, rando):
+        mock_market, mock_feed, factory, ovl, alice, bob, guardian, rando):
     # loop through 10 times
     n = 10
     total_collateral_long = Decimal(10000)
@@ -328,7 +328,7 @@ def test_multiple_emergency_withdraw(
 
     # shutdown market
     # NOTE: factory.shutdown() tests in factories/market/test_setters.py
-    factory.shutdown(mock_feed, {"from": gov})
+    factory.shutdown(mock_feed, {"from": guardian})
 
     # withdraw remaining collateral for each position
     for id in actual_pos_ids:

--- a/tests/token/conftest.py
+++ b/tests/token/conftest.py
@@ -37,6 +37,11 @@ def governor_role():
     yield web3.solidityKeccak(['string'], ["GOVERNOR"])
 
 
+@pytest.fixture(scope="module")
+def guardian_role():
+    yield web3.solidityKeccak(['string'], ["GUARDIAN"])
+
+
 @pytest.fixture(scope="module", params=[8000000])
 def create_token(gov, alice, bob, minter_role, request):
     sup = request.param
@@ -99,8 +104,22 @@ def create_governor(token, gov, accounts, governor_role):
 
 
 @pytest.fixture(scope="module")
+def create_guardian(token, gov, accounts, guardian_role):
+    def create_guardian(tok=token, governance=gov):
+        tok.grantRole(guardian_role, accounts[7], {"from": gov})
+        return accounts[7]
+
+    yield create_guardian
+
+
+@pytest.fixture(scope="module")
 def governor(create_governor):
     yield create_governor()
+
+
+@pytest.fixture(scope="module")
+def guardian(create_guardian):
+    yield create_guardian()
 
 
 @pytest.fixture(scope="module")

--- a/tests/token/test_token_permissions.py
+++ b/tests/token/test_token_permissions.py
@@ -26,10 +26,21 @@ def test_admin_grant_governor_role_then_revoke(token, admin, rando,
     assert token.hasRole(governor_role, rando) is False
 
 
+def test_admin_grant_guardian_role_then_revoke(token, admin, rando,
+                                               guardian_role):
+    token.grantRole(guardian_role, rando, {"from": admin})
+    assert token.hasRole(guardian_role, rando) is True
+
+    token.revokeRole(guardian_role, rando, {"from": admin})
+    assert token.hasRole(guardian_role, rando) is False
+
+
 def test_grant_roles_reverts_when_not_admin(token, rando, minter_role,
-                                            burner_role, governor_role):
+                                            burner_role, governor_role,
+                                            guardian_role):
     admin_role = token.DEFAULT_ADMIN_ROLE()
-    roles = [minter_role, burner_role, governor_role, admin_role]
+    roles = [minter_role, burner_role, governor_role,
+             guardian_role, admin_role]
     for role in roles:
         with reverts():
             token.grantRole(role, rando, {"from": rando})


### PR DESCRIPTION
* Modified uniswap v3 feed factory to deploy a feed that does not reserves from the ovl x pool

* test asserting correctness of consult function for uni feed when no reserve

* quanto feed without reserve test for latest with many calls

* test for many calls with latest and test for view for quanto without reserve

* created separate factory for deploying feeds  without reserves

* deployment test for no reserve factory

* successful deployment of no reserve feed from no reserve factory

* test for when no reserve feed already exists and when misparameterized, eg the uni pool does not exist

* Fix python linting

* Fixed solidity linting

* added method for removing feed factories

* introduced guardian role for shutdown function. updated corresponding tests to shut down market with guardian address.

* removed extra test and executed python linting

* corrected natspec for removing feed in factory, added test asserting address must be recognized as a feed to be removed

* python linted

* Added remove feed function from factory interface

* corrected interface function

* corrected name and comment in test asserting must be guardian

Co-authored-by: deepsp94 <anantsp94@gmail.com>
Co-authored-by: c-note <dongustavo20@gmail.com>